### PR TITLE
new bactions proxy

### DIFF
--- a/src/abi/BActions.json
+++ b/src/abi/BActions.json
@@ -126,36 +126,6 @@
                     "type": "address"
                 },
                 {
-                    "internalType": "address[]",
-                    "name": "tokens",
-                    "type": "address[]"
-                },
-                {
-                    "internalType": "uint256[]",
-                    "name": "balances",
-                    "type": "uint256[]"
-                },
-                {
-                    "internalType": "uint256[]",
-                    "name": "denorms",
-                    "type": "uint256[]"
-                }
-            ],
-            "name": "rebind",
-            "outputs": [],
-            "payable": false,
-            "stateMutability": "nonpayable",
-            "type": "function"
-        },
-        {
-            "constant": false,
-            "inputs": [
-                {
-                    "internalType": "contract BPool",
-                    "name": "pool",
-                    "type": "address"
-                },
-                {
                     "internalType": "address",
                     "name": "newController",
                     "type": "address"
@@ -202,6 +172,36 @@
                 }
             ],
             "name": "setSwapFee",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "internalType": "contract BPool",
+                    "name": "pool",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address[]",
+                    "name": "tokens",
+                    "type": "address[]"
+                },
+                {
+                    "internalType": "uint256[]",
+                    "name": "balances",
+                    "type": "uint256[]"
+                },
+                {
+                    "internalType": "uint256[]",
+                    "name": "denorms",
+                    "type": "uint256[]"
+                }
+            ],
+            "name": "setTokens",
             "outputs": [],
             "payable": false,
             "stateMutability": "nonpayable",

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -31,7 +31,7 @@
         "chainId": 42,
         "defaultPrecision": 4,
         "bFactory": "0x8f7F78080219d4066A8036ccD30D588B416a40DB",
-        "bActions": "0x1266F7220cCc4f1957b3f1EA713F3F434Fc3BDc7",
+        "bActions": "0x02EFDB542B9390ae7C1620B29674e02F9c0d86CC",
         "dsProxyRegistry": "0x130767E0cf05469CF11Fa3fcf270dfC1f52b9072",
         "proxy": "0xdf6F5B1f49eFf8d1C45f2AADC045cB91C33e44b8",
         "weth": "0xd0A1E359811322d97991E03f863a0C30C2cF029C",

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -147,7 +147,7 @@
         "chainId": 1,
         "defaultPrecision": 4,
         "bFactory": "0x9424B1412450D0f8Fc2255FAf6046b98213B76Bd",
-        "bActions": "0x54b28bB7930976839C61f142746cADDBE819A742",
+        "bActions": "0xde4A25A0b9589689945d842c5ba0CF4f0D4eB3ac",
         "dsProxyRegistry": "0x4678f0a6958e4D2Bc4F1BAF7Bc52E8F3564f3fE4",
         "proxy": "0x6317C5e82A06E1d8bf200d21F4510Ac2c038AC81",
         "weth": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",


### PR DESCRIPTION
- Fixes broken tokens that require reset to 0 approvals

Also, @Destiner `setTokens` is the new name for the function instead of `rebind` to make it clear that it's not just a wrapper around the underlying rebind. (For when you move onto private pool management)