### PR TITLE
Add first batch of tokens to whitelist

### DIFF
--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "POWR",
+                "address": "0x595832F8FC6BF59c85C527fEC3740A1b7a361269",
+                "decimals": 6,
+                "ticker": "POWR",
+                "iconAddress": "0x595832F8FC6BF59c85C527fEC3740A1b7a361269",
+                "precision": 2,
+                "chartColor": "#433455"
+            },
+            {
                 "symbol": "DNT",
                 "address": "0x0AbdAce70D3790235af448C88547603b945604ea",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "CEL",
+                "address": "0xaaAEBE6Fe48E54f431b0C390CfaF0b017d09D42d",
+                "decimals": 4,
+                "ticker": "CEL",
+                "iconAddress": "0xaaAEBE6Fe48E54f431b0C390CfaF0b017d09D42d",
+                "precision": 2,
+                "chartColor": "#7ca1c0"
+            },
+            {
                 "symbol": "SHUF",
                 "address": "0x3A9FfF453d50D4Ac52A6890647b823379ba36B9E",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "cREP",
+                "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
+                "decimals": 8,
+                "ticker": "cREP",
+                "iconAddress": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
+                "precision": 2,
+                "chartColor": "#220730"
+            },
+            {
                 "symbol": "EDO",
                 "address": "0xCeD4E93198734dDaFf8492d525Bd258D49eb388E",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "MLN",
+                "address": "0xec67005c4E498Ec7f55E092bd1d35cbC47C91892",
+                "decimals": 18,
+                "ticker": "MLN",
+                "iconAddress": "0xec67005c4E498Ec7f55E092bd1d35cbC47C91892",
+                "precision": 2,
+                "chartColor": "#8b5580"
+            },
+            {
                 "symbol": "RSR",
                 "address": "0x8762db106B2c2A0bccB3A80d1Ed41273552616E8",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "PAXG",
+                "address": "0x45804880De22913dAFE09f4980848ECE6EcbAf78",
+                "decimals": 18,
+                "ticker": "PAXG",
+                "iconAddress": "0x45804880De22913dAFE09f4980848ECE6EcbAf78",
+                "precision": 4,
+                "chartColor": "#a593a5"
+            },
+            {
                 "symbol": "DEXT",
                 "address": "0x26CE25148832C04f3d7F26F32478a9fe55197166",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "PAX",
+                "address": "0x8E870D67F660D95d5be530380D0eC0bd388289E1",
+                "decimals": 18,
+                "ticker": "PAX",
+                "iconAddress": "0x8E870D67F660D95d5be530380D0eC0bd388289E1",
+                "precision": 2,
+                "chartColor": "#666092"
+            },
+            {
                 "symbol": "PAXG",
                 "address": "0x45804880De22913dAFE09f4980848ECE6EcbAf78",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "UBT",
+                "address": "0x8400D94A5cb0fa0D041a3788e395285d61c9ee5e",
+                "decimals": 8,
+                "ticker": "UBT",
+                "iconAddress": "0x8400D94A5cb0fa0D041a3788e395285d61c9ee5e",
+                "precision": 2,
+                "chartColor": "#433455"
+            },
+            {
                 "symbol": "FUN",
                 "address": "0x419D0d8BdD9aF5e606Ae2232ed285Aff190E711b",
                 "decimals": 8,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "AGI",
+                "address": "0x8eB24319393716668D768dCEC29356ae9CfFe285",
+                "decimals": 8,
+                "ticker": "AGI",
+                "iconAddress": "0x8eB24319393716668D768dCEC29356ae9CfFe285",
+                "precision": 2,
+                "chartColor": "#8d6268"
+            },
+            {
                 "symbol": "LPT",
                 "address": "0x58b6A8A3302369DAEc383334672404Ee733aB239",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "CVC",
+                "address": "0x41e5560054824eA6B0732E656E3Ad64E20e94E45",
+                "decimals": 8,
+                "ticker": "CVC",
+                "iconAddress": "0x41e5560054824eA6B0732E656E3Ad64E20e94E45",
+                "precision": 2,
+                "chartColor": "#c5ccb8"
+            },
+            {
                 "symbol": "MANA",
                 "address": "0x0F5D2fB29fb7d3CFeE444a200298f468908cC942",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "BLZ",
+                "address": "0x5732046A883704404F284Ce41FfADd5b007FD668",
+                "decimals": 18,
+                "ticker": "BLZ",
+                "iconAddress": "0x5732046A883704404F284Ce41FfADd5b007FD668",
+                "precision": 2,
+                "chartColor": "#6eaa78"
+            },
+            {
                 "symbol": "MATIC",
                 "address": "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "LPT",
+                "address": "0x58b6A8A3302369DAEc383334672404Ee733aB239",
+                "decimals": 18,
+                "ticker": "LPT",
+                "iconAddress": "0x58b6A8A3302369DAEc383334672404Ee733aB239",
+                "precision": 2,
+                "chartColor": "#416aa3"
+            },
+            {
                 "symbol": "TUSD",
                 "address": "0x0000000000085d4780B73119b644AE5ecd22b376",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "TFD",
+                "address": "0xE5F166c0D8872B68790061317BB6CcA04582C912",
+                "decimals": 18,
+                "ticker": "TFD",
+                "iconAddress": "0xE5F166c0D8872B68790061317BB6CcA04582C912",
+                "precision": 2,
+                "chartColor": "#557064"
+            },
+            {
                 "symbol": "BLZ",
                 "address": "0x5732046A883704404F284Ce41FfADd5b007FD668",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "DMG",
+                "address": "0xEd91879919B71bB6905f23af0A68d231EcF87b14",
+                "decimals": 18,
+                "ticker": "DMG",
+                "iconAddress": "0xEd91879919B71bB6905f23af0A68d231EcF87b14",
+                "precision": 2,
+                "chartColor": "#c28d75"
+            },
+            {
                 "symbol": "cZRX",
                 "address": "0xB3319f5D18Bc0D84dD1b4825Dcde5d5f7266d407",
                 "decimals": 8,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "MANA",
+                "address": "0x0F5D2fB29fb7d3CFeE444a200298f468908cC942",
+                "decimals": 18,
+                "ticker": "MANA",
+                "iconAddress": "0x0F5D2fB29fb7d3CFeE444a200298f468908cC942",
+                "precision": 2,
+                "chartColor": "#9a9a97"
+            },
+            {
                 "symbol": "DATA",
                 "address": "0x0Cf0Ee63788A0849fE5297F3407f701E122cC023",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "cBAT",
+                "address": "0x6C8c6b02E7b2BE14d4fA6022Dfd6d75921D90E4E",
+                "decimals": 8,
+                "ticker": "cBAT",
+                "iconAddress": "0x6C8c6b02E7b2BE14d4fA6022Dfd6d75921D90E4E",
+                "precision": 2,
+                "chartColor": "#666092"
+            },
+            {
                 "symbol": "STAKE",
                 "address": "0x0Ae055097C6d159879521C384F1D2123D1f195e6",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "TRB",
+                "address": "0x0Ba45A8b5d5575935B8158a88C631E9F9C95a2e5",
+                "decimals": 18,
+                "ticker": "TRB",
+                "iconAddress": "0x0Ba45A8b5d5575935B8158a88C631E9F9C95a2e5",
+                "precision": 2,
+                "chartColor": "#9a4f50"
+            },
+            {
                 "symbol": "QNT",
                 "address": "0x4a220E6096B25EADb88358cb44068A3248254675",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "TRAC",
+                "address": "0xaA7a9CA87d3694B5755f213B5D04094b8d0F0A6F",
+                "decimals": 18,
+                "ticker": "TRAC",
+                "iconAddress": "0xaA7a9CA87d3694B5755f213B5D04094b8d0F0A6F",
+                "precision": 2,
+                "chartColor": "#9d9f7f"
+            },
+            {
                 "symbol": "TFD",
                 "address": "0xE5F166c0D8872B68790061317BB6CcA04582C912",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -847,15 +847,6 @@
                 "chartColor": "#7ca1c0"
             },
             {
-                "symbol": "SHUF",
-                "address": "0x3A9FfF453d50D4Ac52A6890647b823379ba36B9E",
-                "decimals": 18,
-                "ticker": "SHUF",
-                "iconAddress": "0x3A9FfF453d50D4Ac52A6890647b823379ba36B9E",
-                "precision": 2,
-                "chartColor": "#c28d75"
-            },
-            {
                 "symbol": "TRB",
                 "address": "0x0Ba45A8b5d5575935B8158a88C631E9F9C95a2e5",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "BLT",
+                "address": "0x107c4504cd79C5d2696Ea0030a8dD4e92601B82e",
+                "decimals": 18,
+                "ticker": "BLT",
+                "iconAddress": "0x107c4504cd79C5d2696Ea0030a8dD4e92601B82e",
+                "precision": 2,
+                "chartColor": "#8b5580"
+            },
+            {
                 "symbol": "CVC",
                 "address": "0x41e5560054824eA6B0732E656E3Ad64E20e94E45",
                 "decimals": 8,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -694,15 +694,6 @@
                 "chartColor": "#a593a5"
             },
             {
-                "symbol": "DEXT",
-                "address": "0x26CE25148832C04f3d7F26F32478a9fe55197166",
-                "decimals": 18,
-                "ticker": "DEXT",
-                "iconAddress": "0x26CE25148832C04f3d7F26F32478a9fe55197166",
-                "precision": 2,
-                "chartColor": "#c38890"
-            },
-            {
                 "symbol": "BLT",
                 "address": "0x107c4504cd79C5d2696Ea0030a8dD4e92601B82e",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "STORJ",
+                "address": "0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC",
+                "decimals": 8,
+                "ticker": "STORJ",
+                "iconAddress": "0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC",
+                "precision": 2,
+                "chartColor": "#7e9e99"
+            },
+            {
                 "symbol": "MCX",
                 "address": "0xd15eCDCF5Ea68e3995b2D0527A0aE0a3258302F8",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "FOAM",
+                "address": "0x4946Fcea7C692606e8908002e55A582af44AC121",
+                "decimals": 18,
+                "ticker": "FOAM",
+                "iconAddress": "0x4946Fcea7C692606e8908002e55A582af44AC121",
+                "precision": 2,
+                "chartColor": "#6e6962"
+            },
+            {
                 "symbol": "DIP",
                 "address": "0xc719d010B63E5bbF2C0551872CD5316ED26AcD83",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "BNT",
+                "address": "0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C",
+                "decimals": 18,
+                "ticker": "BNT",
+                "iconAddress": "0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C",
+                "precision": 2,
+                "chartColor": "#c5ccb8"
+            },
+            {
                 "symbol": "PRO",
                 "address": "0x9041Fe5B3FDEA0f5e4afDC17e75180738D877A01",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "QNT",
+                "address": "0x4a220E6096B25EADb88358cb44068A3248254675",
+                "decimals": 18,
+                "ticker": "QNT",
+                "iconAddress": "0x4a220E6096B25EADb88358cb44068A3248254675",
+                "precision": 2,
+                "chartColor": "#666092"
+            },
+            {
                 "symbol": "SNT",
                 "address": "0x744d70FDBE2Ba4CF95131626614a1763DF805B9E",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "SHUF",
+                "address": "0x3A9FfF453d50D4Ac52A6890647b823379ba36B9E",
+                "decimals": 18,
+                "ticker": "SHUF",
+                "iconAddress": "0x3A9FfF453d50D4Ac52A6890647b823379ba36B9E",
+                "precision": 2,
+                "chartColor": "#c28d75"
+            },
+            {
                 "symbol": "TRB",
                 "address": "0x0Ba45A8b5d5575935B8158a88C631E9F9C95a2e5",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -676,15 +676,6 @@
                 "chartColor": "#666092"
             },
             {
-                "symbol": "PAXG",
-                "address": "0x45804880De22913dAFE09f4980848ECE6EcbAf78",
-                "decimals": 18,
-                "ticker": "PAXG",
-                "iconAddress": "0x45804880De22913dAFE09f4980848ECE6EcbAf78",
-                "precision": 4,
-                "chartColor": "#a593a5"
-            },
-            {
                 "symbol": "BLT",
                 "address": "0x107c4504cd79C5d2696Ea0030a8dD4e92601B82e",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -647,6 +647,15 @@
                 "iconAddress": "0x985dd3D42De1e256d09e1c10F112bCCB8015AD41",
                 "precision": 2,
                 "chartColor": "#220730"
+            },
+            {
+                "symbol": "JRT",
+                "address": "0x8A9C67fee641579dEbA04928c4BC45F66e26343A",
+                "decimals": 18,
+                "ticker": "JRT",
+                "iconAddress": "0x8A9C67fee641579dEbA04928c4BC45F66e26343A",
+                "precision": 2,
+                "chartColor": "#6f6776"
             }
         ],
         "warnings": ["0x4f3AfEC4E5a3F2A6a1A411DEF7D7dFe50eE057bF"],

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "PRO",
+                "address": "0x9041Fe5B3FDEA0f5e4afDC17e75180738D877A01",
+                "decimals": 18,
+                "ticker": "PRO",
+                "iconAddress": "0x9041Fe5B3FDEA0f5e4afDC17e75180738D877A01",
+                "precision": 2,
+                "chartColor": "#9a9a97"
+            },
+            {
                 "symbol": "JRT",
                 "address": "0x8A9C67fee641579dEbA04928c4BC45F66e26343A",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "OWL",
+                "address": "0x1A5F9352Af8aF974bFC03399e3767DF6370d82e4",
+                "decimals": 18,
+                "ticker": "OWL",
+                "iconAddress": "0x1A5F9352Af8aF974bFC03399e3767DF6370d82e4",
+                "precision": 2,
+                "chartColor": "#be955c"
+            },
+            {
                 "symbol": "AGI",
                 "address": "0x8eB24319393716668D768dCEC29356ae9CfFe285",
                 "decimals": 8,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "BCDT",
+                "address": "0xAcfa209Fb73bF3Dd5bBfb1101B9Bc999C49062a5",
+                "decimals": 18,
+                "ticker": "BCDT",
+                "iconAddress": "0xAcfa209Fb73bF3Dd5bBfb1101B9Bc999C49062a5",
+                "precision": 2,
+                "chartColor": "#6eaa78"
+            },
+            {
                 "symbol": "IDEX",
                 "address": "0xB705268213D593B8FD88d3FDEFF93AFF5CbDcfAE",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "ANJ",
+                "address": "0xcD62b1C403fa761BAadFC74C525ce2B51780b184",
+                "decimals": 18,
+                "ticker": "ANJ",
+                "iconAddress": "0xcD62b1C403fa761BAadFC74C525ce2B51780b184",
+                "precision": 2,
+                "chartColor": "#6f6776"
+            },
+            {
                 "symbol": "UBT",
                 "address": "0x8400D94A5cb0fa0D041a3788e395285d61c9ee5e",
                 "decimals": 8,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "DGX",
+                "address": "0x4f3AfEC4E5a3F2A6a1A411DEF7D7dFe50eE057bF",
+                "decimals": 9,
+                "ticker": "DGX",
+                "iconAddress": "0x4f3AfEC4E5a3F2A6a1A411DEF7D7dFe50eE057bF",
+                "precision": 2,
+                "chartColor": "#be955c"
+            },
+            {
                 "symbol": "LEV",
                 "address": "0x0F4CA92660Efad97a9a70CB0fe969c755439772C",
                 "decimals": 9,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "CHZ",
+                "address": "0x3506424F91fD33084466F402d5D97f05F8e3b4AF",
+                "decimals": 18,
+                "ticker": "CHZ",
+                "iconAddress": "0x3506424F91fD33084466F402d5D97f05F8e3b4AF",
+                "precision": 2,
+                "chartColor": "#c38890"
+            },
+            {
                 "symbol": "MLN",
                 "address": "0xec67005c4E498Ec7f55E092bd1d35cbC47C91892",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "SHIP",
+                "address": "0xe25b0BBA01Dc5630312B6A21927E578061A13f55",
+                "decimals": 18,
+                "ticker": "SHIP",
+                "iconAddress": "0xe25b0BBA01Dc5630312B6A21927E578061A13f55",
+                "precision": 2,
+                "chartColor": "#7e9e99"
+            },
+            {
                 "symbol": "TRAC",
                 "address": "0xaA7a9CA87d3694B5755f213B5D04094b8d0F0A6F",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "EDO",
+                "address": "0xCeD4E93198734dDaFf8492d525Bd258D49eb388E",
+                "decimals": 18,
+                "ticker": "EDO",
+                "iconAddress": "0xCeD4E93198734dDaFf8492d525Bd258D49eb388E",
+                "precision": 2,
+                "chartColor": "#9a4f50"
+            },
+            {
                 "symbol": "PAX",
                 "address": "0x8E870D67F660D95d5be530380D0eC0bd388289E1",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "MCX",
+                "address": "0xd15eCDCF5Ea68e3995b2D0527A0aE0a3258302F8",
+                "decimals": 18,
+                "ticker": "MCX",
+                "iconAddress": "0xd15eCDCF5Ea68e3995b2D0527A0aE0a3258302F8",
+                "precision": 2,
+                "chartColor": "#9d9f7f"
+            },
+            {
                 "symbol": "BCDT",
                 "address": "0xAcfa209Fb73bF3Dd5bBfb1101B9Bc999C49062a5",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -469,15 +469,6 @@
                 "chartColor": "#6e6962"
             },
             {
-                "symbol": "STA",
-                "address": "0xa7DE087329BFcda5639247F96140f9DAbe3DeED1",
-                "decimals": 18,
-                "ticker": "STA",
-                "iconAddress": "0xa7DE087329BFcda5639247F96140f9DAbe3DeED1",
-                "precision": 2,
-                "chartColor": "#6e6962"
-            },
-            {
                 "symbol": "REN",
                 "address": "0x408e41876cCCDC0F92210600ef50372656052a38",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "AUC",
+                "address": "0xc12d099be31567add4e4e4d0D45691C3F58f5663",
+                "decimals": 18,
+                "ticker": "AUC",
+                "iconAddress": "0xc12d099be31567add4e4e4d0D45691C3F58f5663",
+                "precision": 2,
+                "chartColor": "#68aca9"
+            },
+            {
                 "symbol": "OWL",
                 "address": "0x1A5F9352Af8aF974bFC03399e3767DF6370d82e4",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "BUIDL",
+                "address": "0xD6F0Bb2A45110f819e908a915237D652Ac7c5AA8",
+                "decimals": 18,
+                "ticker": "BUIDL",
+                "iconAddress": "0xD6F0Bb2A45110f819e908a915237D652Ac7c5AA8",
+                "precision": 2,
+                "chartColor": "#416aa3"
+            },
+            {
                 "symbol": "CEL",
                 "address": "0xaaAEBE6Fe48E54f431b0C390CfaF0b017d09D42d",
                 "decimals": 4,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "LEV",
+                "address": "0x0F4CA92660Efad97a9a70CB0fe969c755439772C",
+                "decimals": 9,
+                "ticker": "LEV",
+                "iconAddress": "0x0F4CA92660Efad97a9a70CB0fe969c755439772C",
+                "precision": 2,
+                "chartColor": "#8d6268"
+            },
+            {
                 "symbol": "BUIDL",
                 "address": "0xD6F0Bb2A45110f819e908a915237D652Ac7c5AA8",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -667,6 +667,15 @@
                 "chartColor": "#9a4f50"
             },
             {
+                "symbol": "BAL",
+                "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "decimals": 18,
+                "ticker": "BAL",
+                "iconAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "precision": 2,
+                "chartColor": "#c5ccb8"
+            },
+            {
                 "symbol": "PAX",
                 "address": "0x8E870D67F660D95d5be530380D0eC0bd388289E1",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "DATA",
+                "address": "0x0Cf0Ee63788A0849fE5297F3407f701E122cC023",
+                "decimals": 18,
+                "ticker": "DATA",
+                "iconAddress": "0x0Cf0Ee63788A0849fE5297F3407f701E122cC023",
+                "precision": 2,
+                "chartColor": "#6f6776"
+            },
+            {
                 "symbol": "POWR",
                 "address": "0x595832F8FC6BF59c85C527fEC3740A1b7a361269",
                 "decimals": 6,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "IDEX",
+                "address": "0xB705268213D593B8FD88d3FDEFF93AFF5CbDcfAE",
+                "decimals": 18,
+                "ticker": "IDEX",
+                "iconAddress": "0xB705268213D593B8FD88d3FDEFF93AFF5CbDcfAE",
+                "precision": 2,
+                "chartColor": "#93a167"
+            },
+            {
                 "symbol": "mUSD",
                 "address": "0xe2f2a5C287993345a840Db3B0845fbC70f5935a5",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "USD++",
+                "address": "0x9A48BD0EC040ea4f1D3147C025cd4076A2e71e3e",
+                "decimals": 18,
+                "ticker": "USD++",
+                "iconAddress": "0x9A48BD0EC040ea4f1D3147C025cd4076A2e71e3e",
+                "precision": 2,
+                "chartColor": "#387080"
+            },
+            {
                 "symbol": "AUC",
                 "address": "0xc12d099be31567add4e4e4d0D45691C3F58f5663",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "SNT",
+                "address": "0x744d70FDBE2Ba4CF95131626614a1763DF805B9E",
+                "decimals": 18,
+                "ticker": "SNT",
+                "iconAddress": "0x744d70FDBE2Ba4CF95131626614a1763DF805B9E",
+                "precision": 2,
+                "chartColor": "#a593a5"
+            },
+            {
                 "symbol": "CHZ",
                 "address": "0x3506424F91fD33084466F402d5D97f05F8e3b4AF",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "DIP",
+                "address": "0xc719d010B63E5bbF2C0551872CD5316ED26AcD83",
+                "decimals": 18,
+                "ticker": "DIP",
+                "iconAddress": "0xc719d010B63E5bbF2C0551872CD5316ED26AcD83",
+                "precision": 2,
+                "chartColor": "#387080"
+            },
+            {
                 "symbol": "AMPL",
                 "address": "0xD46bA6D942050d489DBd938a2C909A5d5039A161",
                 "decimals": 9,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "MATIC",
+                "address": "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0",
+                "decimals": 18,
+                "ticker": "MATIC",
+                "iconAddress": "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0",
+                "precision": 2,
+                "chartColor": "#93a167"
+            },
+            {
                 "symbol": "FOAM",
                 "address": "0x4946Fcea7C692606e8908002e55A582af44AC121",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "STAKE",
+                "address": "0x0Ae055097C6d159879521C384F1D2123D1f195e6",
+                "decimals": 18,
+                "ticker": "STAKE",
+                "iconAddress": "0x0Ae055097C6d159879521C384F1D2123D1f195e6",
+                "precision": 2,
+                "chartColor": "#a593a5"
+            },
+            {
                 "symbol": "RLC",
                 "address": "0x607F4C5BB672230e8672085532f7e901544a7375",
                 "decimals": 9,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "RSR",
+                "address": "0x8762db106B2c2A0bccB3A80d1Ed41273552616E8",
+                "decimals": 18,
+                "ticker": "RSR",
+                "iconAddress": "0x8762db106B2c2A0bccB3A80d1Ed41273552616E8",
+                "precision": 2,
+                "chartColor": "#c5ccb8"
+            },
+            {
                 "symbol": "HOT",
                 "address": "0x6c6EE5e31d828De241282B9606C8e98Ea48526E2",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "cZRX",
+                "address": "0xB3319f5D18Bc0D84dD1b4825Dcde5d5f7266d407",
+                "decimals": 8,
+                "ticker": "cZRX",
+                "iconAddress": "0xB3319f5D18Bc0D84dD1b4825Dcde5d5f7266d407",
+                "precision": 2,
+                "chartColor": "#9a4f50"
+            },
+            {
                 "symbol": "cBAT",
                 "address": "0x6C8c6b02E7b2BE14d4fA6022Dfd6d75921D90E4E",
                 "decimals": 8,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "TUSD",
+                "address": "0x0000000000085d4780B73119b644AE5ecd22b376",
+                "decimals": 18,
+                "ticker": "TUSD",
+                "iconAddress": "0x0000000000085d4780B73119b644AE5ecd22b376",
+                "precision": 2,
+                "chartColor": "#7ca1c0"
+            },
+            {
                 "symbol": "DMG",
                 "address": "0xEd91879919B71bB6905f23af0A68d231EcF87b14",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "AMPL",
+                "address": "0xD46bA6D942050d489DBd938a2C909A5d5039A161",
+                "decimals": 9,
+                "ticker": "AMPL",
+                "iconAddress": "0xD46bA6D942050d489DBd938a2C909A5d5039A161",
+                "precision": 2,
+                "chartColor": "#68aca9"
+            },
+            {
                 "symbol": "DGX",
                 "address": "0x4f3AfEC4E5a3F2A6a1A411DEF7D7dFe50eE057bF",
                 "decimals": 9,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "mUSD",
+                "address": "0xe2f2a5C287993345a840Db3B0845fbC70f5935a5",
+                "decimals": 18,
+                "ticker": "mUSD",
+                "iconAddress": "0xe2f2a5C287993345a840Db3B0845fbC70f5935a5",
+                "precision": 2,
+                "chartColor": "#6e6962"
+            },
+            {
                 "symbol": "USD++",
                 "address": "0x9A48BD0EC040ea4f1D3147C025cd4076A2e71e3e",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -652,7 +652,7 @@
                 "symbol": "RLC",
                 "address": "0x607F4C5BB672230e8672085532f7e901544a7375",
                 "decimals": 9,
-                "ticker": "REQ",
+                "ticker": "RLC",
                 "iconAddress": "0x607F4C5BB672230e8672085532f7e901544a7375",
                 "precision": 2,
                 "chartColor": "#c38890"

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "DNT",
+                "address": "0x0AbdAce70D3790235af448C88547603b945604ea",
+                "decimals": 18,
+                "ticker": "DNT",
+                "iconAddress": "0x0AbdAce70D3790235af448C88547603b945604ea",
+                "precision": 2,
+                "chartColor": "#5d6872"
+            },
+            {
                 "symbol": "SHIP",
                 "address": "0xe25b0BBA01Dc5630312B6A21927E578061A13f55",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "DEXT",
+                "address": "0x26CE25148832C04f3d7F26F32478a9fe55197166",
+                "decimals": 18,
+                "ticker": "DEXT",
+                "iconAddress": "0x26CE25148832C04f3d7F26F32478a9fe55197166",
+                "precision": 2,
+                "chartColor": "#c38890"
+            },
+            {
                 "symbol": "BLT",
                 "address": "0x107c4504cd79C5d2696Ea0030a8dD4e92601B82e",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "HOT",
+                "address": "0x6c6EE5e31d828De241282B9606C8e98Ea48526E2",
+                "decimals": 18,
+                "ticker": "HOT",
+                "iconAddress": "0x6c6EE5e31d828De241282B9606C8e98Ea48526E2",
+                "precision": 2,
+                "chartColor": "#9a9a97"
+            },
+            {
                 "symbol": "ANJ",
                 "address": "0xcD62b1C403fa761BAadFC74C525ce2B51780b184",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "REQ",
+                "address": "0x8f8221aFbB33998d8584A2B05749bA73c37a938a",
+                "decimals": 18,
+                "ticker": "REQ",
+                "iconAddress": "0x8f8221aFbB33998d8584A2B05749bA73c37a938a",
+                "precision": 2,
+                "chartColor": "#8b5580"
+            },
+            {
                 "symbol": "BNT",
                 "address": "0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C",
                 "decimals": 18,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "FUN",
+                "address": "0x419D0d8BdD9aF5e606Ae2232ed285Aff190E711b",
+                "decimals": 8,
+                "ticker": "FUN",
+                "iconAddress": "0x419D0d8BdD9aF5e606Ae2232ed285Aff190E711b",
+                "precision": 2,
+                "chartColor": "#5d6872"
+            },
+            {
                 "symbol": "STORJ",
                 "address": "0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC",
                 "decimals": 8,

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -649,6 +649,15 @@
                 "chartColor": "#220730"
             },
             {
+                "symbol": "RLC",
+                "address": "0x607F4C5BB672230e8672085532f7e901544a7375",
+                "decimals": 9,
+                "ticker": "REQ",
+                "iconAddress": "0x607F4C5BB672230e8672085532f7e901544a7375",
+                "precision": 2,
+                "chartColor": "#c38890"
+            },
+            {
                 "symbol": "REQ",
                 "address": "0x8f8221aFbB33998d8584A2B05749bA73c37a938a",
                 "decimals": 18,


### PR DESCRIPTION
This merge would add a large selection of new tokens to the pool-management whitelist, with the intention being that these will also be considered eligible for BAL mining. All tokens on this list were subjectively non-contentious on Discord. Each, with the exception of USD++ which should be fixed soon, has a Trust Wallet logo. Each is verified on etherscan, and to the best of my knowledge, each fulfills the critical criteria for cooperation with Balancer protocol. The great majority of these are already sitting in operational pools. The list was vetted by a few esteemed community members.