### PR TITLE
Hotfix mUSD conflict with Master USD

### DIFF
--- a/src/provider/market.ts
+++ b/src/provider/market.ts
@@ -5,6 +5,8 @@ import { bnum } from '../utils/helpers';
 const pricesBackup = require('./pricesBackup.json');
 const listBackup = require('./listBackup.json');
 
+const conflictSymbols = ['master-usd'];
+
 const MARKET_API_URL =
     process.env.REACT_APP_MARKET_API_URL || 'https://api.coingecko.com/api/v3';
 
@@ -88,7 +90,7 @@ export async function fetchAssetList(
     const result: MarketAssetMap = {};
     symbolsToFetch.forEach(assetSymbol => {
         const match = assets.find(
-            value => value.symbol.toUpperCase() === assetSymbol.toUpperCase()
+            value => value.symbol.toUpperCase() === assetSymbol.toUpperCase() && !conflictSymbols.includes(value.id)
         );
         if (match) {
             result[assetSymbol] = formatAsset(match);


### PR DESCRIPTION
There is an issue with the price of mUSD, when someone make a pool 50 DAI / 50 mUSD the amount will be off:

![image](https://user-images.githubusercontent.com/16245250/85921023-0d449580-b8a3-11ea-80c1-bdff69f96cf3.png)

With the fix it look like this:
![image](https://user-images.githubusercontent.com/16245250/85921064-66142e00-b8a3-11ea-8674-466b3de88a18.png)

I didn't wanted to change to much of the code for fix mUSD so i made this small fix, but i assume a better fix is to not rely on the Coingecko symbols but on Coingecko ids or addresses (there is an endpoint from coingecko to check usd price by token addresses) otherwise it will happen on others tokens the UI should not assume that all symbols are unique.