### PR TITLE
Fix missing checksums

### DIFF
--- a/src/deployed.json
+++ b/src/deployed.json
@@ -650,10 +650,10 @@
             },
             {
                 "symbol": "cREP",
-                "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
+                "address": "0x158079Ee67Fce2f58472A96584A73C7Ab9AC95c1",
                 "decimals": 8,
                 "ticker": "cREP",
-                "iconAddress": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
+                "iconAddress": "0x158079Ee67Fce2f58472A96584A73C7Ab9AC95c1",
                 "precision": 2,
                 "chartColor": "#220730"
             },
@@ -668,10 +668,10 @@
             },
             {
                 "symbol": "BAL",
-                "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "address": "0xba100000625a3754423978a60c9317c58a424e3D",
                 "decimals": 18,
                 "ticker": "BAL",
-                "iconAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "iconAddress": "0xba100000625a3754423978a60c9317c58a424e3D",
                 "precision": 2,
                 "chartColor": "#c5ccb8"
             },


### PR DESCRIPTION
Yesterday I accidentally committed non-checksummed addresses to the whitelist. This affected two tokens:

BAL
cREP

This commit replaces the addresses with the checksummed versions (which will work properly with Trust Wallet for logo extraction).