### PR TITLE
Quick fix to bring pools back - checks for undefined assetData[symbol]

### DIFF
--- a/src/provider/market.ts
+++ b/src/provider/market.ts
@@ -17,7 +17,7 @@ export async function fetchAssetPrices(
 ): Promise<MarketAssetPriceMap> {
     let idQueryString = '';
     symbolsToFetch.forEach((symbol, index) => {
-        if (symbol !== '') {
+        if (symbol !== '' && assetData[symbol] !== undefined) {
             if (index === symbolsToFetch.length - 1) {
                 idQueryString += `${assetData[symbol].id}`;
             } else {


### PR DESCRIPTION
Quick fix to bring pools back. Tested locally and seems ok but not exchaustively tested.