### PR TITLE
fix: update REPV1 ticker to be REP

### DIFF
--- a/src/deployed.json
+++ b/src/deployed.json
@@ -89,7 +89,7 @@
                 "symbol": "REP",
                 "address": "0x8c9e6c40d3402480ACE624730524fACC5482798c",
                 "decimals": 18,
-                "ticker": "REPV1",
+                "ticker": "REP",
                 "iconAddress": "0x1985365e9f78359a9B6AD760e32412f4a445E862",
                 "precision": 4,
                 "chartColor": "#422940"
@@ -253,7 +253,7 @@
                 "symbol": "REP",
                 "address": "0x1985365e9f78359a9B6AD760e32412f4a445E862",
                 "decimals": 18,
-                "ticker": "REPV1",
+                "ticker": "REP",
                 "iconAddress": "0x1985365e9f78359a9B6AD760e32412f4a445E862",
                 "precision": 4,
                 "chartColor": "#6e6962"


### PR DESCRIPTION
Coingecko appears to have updated their ticker which resulted in rootStore.asyncSetup throwing
see: https://twitter.com/AugurProject/status/1281707502233501698