### PR TITLE
fix: prevent broken display AssetPanel on smaller screen sizes

### DIFF
--- a/src/components/CreatePool/AssetOptions.tsx
+++ b/src/components/CreatePool/AssetOptions.tsx
@@ -27,10 +27,11 @@ const AssetPanelContainer = styled.div`
 
 const AssetPanel = styled.div`
     display: flex;
+    flex-grow: 1
     align-items: center;
     justify-content: center;
     flex-direction: column;
-    width: 184px;
+    width: 33%;
     height: 98px;
     cursor: pointer;
     border-right: 1px solid var(--panel-border);

--- a/src/components/Filters/AssetOptions.tsx
+++ b/src/components/Filters/AssetOptions.tsx
@@ -28,10 +28,11 @@ const AssetPanelContainer = styled.div`
 
 const AssetPanel = styled.div`
     display: flex;
+    flex-grow: 1
     align-items: center;
     justify-content: center;
     flex-direction: column;
-    width: 184px;
+    width: 33%;
     height: 98px;
     cursor: pointer;
     border-right: 1px solid var(--panel-border);


### PR DESCRIPTION
Identical fix to that found in https://github.com/balancer-labs/balancer-exchange/pull/147